### PR TITLE
Better default value handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ It's also possible to run the alarm without the GUI on a headless setup, see Usa
 
 ## Setup
 First, install required system packages with  
-```apt install python-all-dev qt5-default ffmpeg festival cvlc portaudio19-dev```  
+```apt install python-all-dev qt5-default ffmpeg festival vlc portaudio19-dev```  
 These include the Qt 5 development package, Festival text-to-speech engine, the command line media player cvlc and audio libraries enabling playback of mp3 files directly in Python.
 
 Next, install Python packages with  

--- a/src/clock.py
+++ b/src/clock.py
@@ -470,7 +470,7 @@ class RadioStreamer:
         """Open a radio stream as a child process. The stream will continue to run
         in the background.
         """
-        args = self.config["args"]
+        args = self.config.get("args", "")
         cmd = "/usr/bin/cvlc {} {}".format(url, args)
         logger.info("Running %s", cmd)
 

--- a/src/clock.py
+++ b/src/clock.py
@@ -71,9 +71,14 @@ class Clock:
         if kwargs.get("debug"):
             logger.debug("Disabling weather plugin")
             self.env.config.set("openweathermap", "enabled", "0")
-            for key in self.env.get_section("plugins"):
-                logger.debug("Disabling %s", key)
-                self.env.config.set("plugins", key, "0")
+
+            # Disable plugins if any listed in the configuration
+            try:
+                for key in self.env.get_section("plugins"):
+                    logger.debug("Disabling %s", key)
+                    self.env.config.set("plugins", key, "0")
+            except KeyError:
+                pass
 
             self.env.rpi_brightness_write_access = True  # Enables brightness buttons
 

--- a/src/handlers/get_next_trains.py
+++ b/src/handlers/get_next_trains.py
@@ -16,7 +16,7 @@ from dateutil import tz
 
 # Define common top level parameters: number of arriving trains
 # and API response values to parse,
-NUMBER_OF_TRAINS = 5
+MAX_NUMBER_OF_TRAINS = 5
 ARRIVING_STATION_CODE = "KE"
 RETURN_TEMPLATE_KEYS = [
     "liveEstimateTime",
@@ -83,14 +83,14 @@ class TrainParser:
             departure_rows.append(d)
 
         departure_rows.sort(key=lambda row: row["sortKey"])
-        return departure_rows[:NUMBER_OF_TRAINS]
+        return departure_rows[:MAX_NUMBER_OF_TRAINS]
 
     def fetch_daily_train_data(self):
         """API call to get the next local arrivivals."""
         URL = "https://rata.digitraffic.fi/api/v1/live-trains/station/{}".format(ARRIVING_STATION_CODE)
         params = {
             "arrived_trains": 1,  # API minumum to already arrived and departed trains is 1
-            "arriving_trains": 10,
+            "arriving_trains": 20,
             "departed_trains": 1
         }
 

--- a/src/plugins/trains.py
+++ b/src/plugins/trains.py
@@ -39,19 +39,26 @@ class TrainPlugin:
                 label.setText("ERR")
             return
 
-        for train, label in zip(trains, self.train_labels):
-            line_id = train["commuterLineID"]
-            scheduled_time = train["scheduledTime"].strftime("%H:%M")
+        for i, label in enumerate(self.train_labels):
+            try:
+                train = trains[i]
+                line_id = train["commuterLineID"]
+                scheduled_time = train["scheduledTime"].strftime("%H:%M")
 
-            # If an estimate exists, display both values
-            if train["liveEstimateTime"]:
-                estimate_time = train["liveEstimateTime"].strftime("%H:%M")
-                msg = "{} {} => {}".format(line_id, scheduled_time, estimate_time)
+                # If an estimate exists, display both values
+                if train["liveEstimateTime"]:
+                    estimate_time = train["liveEstimateTime"].strftime("%H:%M")
+                    msg = "{} {} => {}".format(line_id, scheduled_time, estimate_time)
 
-            else:
-                msg = "{} {}".format(line_id, scheduled_time)
+                else:
+                    msg = "{} {}".format(line_id, scheduled_time)
 
-            if train["cancelled"]:
-                msg = "{} {} CANCELLED".format(line_id, scheduled_time)
+                if train["cancelled"]:
+                    msg = "{} {} CANCELLED".format(line_id, scheduled_time)
 
-            label.setText(msg)
+                label.setText(msg)
+
+            # API response may contain fewer trains than MAX_NUMBER_OF_TRAINS trains,
+            # clear any remaining labels.
+            except IndexError:
+                label.clear()

--- a/src/plugins/trains.py
+++ b/src/plugins/trains.py
@@ -14,12 +14,12 @@ class TrainPlugin:
     def create_widgets(self):
         """Create and set QLabels for displaying train components."""
         self.train_labels = []
-        for i in range(get_next_trains.NUMBER_OF_TRAINS):
+        for i in range(get_next_trains.MAX_NUMBER_OF_TRAINS):
             label = QLabel(self.parent.main_window)
             self.parent.main_window.left_grid.addWidget(label, i, 0)
             self.train_labels.append(label)
 
-        self.parent.main_window.left_grid.setRowStretch(get_next_trains.NUMBER_OF_TRAINS, 1)
+        self.parent.main_window.left_grid.setRowStretch(get_next_trains.MAX_NUMBER_OF_TRAINS, 1)
 
     def setup_train_polling(self):
         """Setup polling for next train departure."""


### PR DESCRIPTION
Train plugin behaviour:
  - Increase maximum number of trains fetched from Digitransit API for better chances to receive enough valid trains to show
  - Clear train labels if not enough trains to show

Config defaults
  - Do not require `args` keyword for the radio player
  - Do not require `plugins` section