### PR TITLE
Backlight control file Debian Bullseye compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This project is built around the following hardware.
  * A speaker
  * A DHT22 temperature and humidity sensor (optional)
 
-While this is built for a Rapsberry Pi, other Linux systems can be used for the main functionality. The GUI does have two bindings to a Raspberry Pi: the buttons for toggling screen brightness and putting it to sleep are disabled on a different system.
+While this is built for a Rapsberry Pi, other Linux systems can be used for the main functionality. The GUI does have two bindings to a Raspberry Pi; buttons toggling screen brightness and turning it off completely are disabled on a non Pi system.
 
 The DHT22 sensor is used for indoor temperature measurement and can be disabled from the configuration, see [configs/README.md](./configs/README.md).
 
@@ -71,12 +71,11 @@ pip install -r requirements.txt
 ```
 Using a virtual environment is recommended
 
-The GUI has Raspberry Pi specific buttons for manipulating the display's backlight brightness. In order to enable these two system files need to be made accessable by the session user (by default `pi`):
+Interacting with the Raspberry Pi's screen brightness is done via two system owned by the root user. The following udev rule will make them writable by all users (adapted from https://github.com/linusg/rpi-backlight).
+
 ```bash
-chown pi /sys/class/backlight/rpi_backlight/brightness
-chown pi /sys/class/backlight/rpi_backlight/bl_power
+echo 'SUBSYSTEM=="backlight",RUN+="/bin/chmod 666 /sys/class/backlight/%k/brightness /sys/class/backlight/%k/bl_power"' | sudo tee -a /etc/udev/rules.d/backlight-permissions.rules
 ```
-This step can be ignored on other systems.
 
 ### Troubleshooting install issues
 Installing PyQt on a Raspberry Pi can be troublesome as it has to be compiled from source. In this case the installation may appear
@@ -107,7 +106,7 @@ If no argument is used, `./configs/default.yaml` will be used.
 
 
 
-The first runs a GUI version of the script. It includes a digital clock interface for current time as well a settings window for setting the alarm. On a Raspberry Pi the GUI can also be used to toggle screen brightness between high and low as well as turning it to sleep entirely. These buttons will be disabled if the system files `/sys/class/backlight/rpi_backlight/brightness` and `/sys/class/backlight/rpi_backlight/bl_power` ether do not exist or are not writable.
+The first runs a GUI version of the script. It includes a digital clock interface for current time as well a settings window for setting the alarm. On a Raspberry Pi the GUI can also be used to toggle screen brightness between high and low as well as turning it off entirely.
 
 The second form generates an alarm based on the configuration file and plays it. This can be used as a purely CLI interface for the alarm. Use cron to manually schedule an alarm.
 
@@ -141,5 +140,5 @@ optional arguments:
 ## Unit tests
 Unit tests can be run from the root folder with
 ```bash
-python -m pytest
+pytest
 ```

--- a/src/GUIWidgets.py
+++ b/src/GUIWidgets.py
@@ -8,7 +8,7 @@ from functools import partial
 from collections import namedtuple
 from enum import Enum
 
-from PyQt5.QtGui import QIcon
+from PyQt5.QtGui import QIcon, QColor
 from PyQt5.QtCore import Qt, QTimer, QSize
 from PyQt5.QtWidgets import (
     QWidget,
@@ -67,7 +67,7 @@ class AlarmWindow(QWidget):
             line_length=10,
             line_width=5,
             speed=1.0,
-            color=(255, 20, 20)
+            color=QColor(255, 20, 20)
         )
         loader_indicator_grid.addWidget(loader_indicator, alignment=Qt.AlignBottom | Qt.AlignLeft)
         loader_indicator.setMinimumWidth(50)  # Force a minimum width to keep left alignment from covering part of the spinner

--- a/src/apconfig.py
+++ b/src/apconfig.py
@@ -39,8 +39,8 @@ class AlarmConfig:
             raise RuntimeError(msg) from e
 
         # Check for write access to Raspberry Pi system backlight brightness files
-        self.rpi_brightness_write_access = all([os.access(p, os.W_OK) for p in [
-            rpi_utils.BRIGHTNESS_FILE, rpi_utils.POWER_FILE]]
+        self.rpi_brightness_write_access = rpi_utils.IS_RASPBERRY_PI and all(
+            [os.access(p, os.W_OK) for p in [ rpi_utils.BRIGHTNESS_FILE, rpi_utils.POWER_FILE ]]
         )
 
     def __getitem__(self, item):

--- a/src/clock.py
+++ b/src/clock.py
@@ -187,13 +187,8 @@ class Clock:
         # Disable backlight manipulation buttons if the underlying system
         # files dont't exists (ie. not a Raspberry Pi) or no write access to them.
         if not self.config.rpi_brightness_write_access:
-            msg = [
-                "No write access to system backlight brightness files:",
-                "\t" + rpi_utils.BRIGHTNESS_FILE,
-                "\t" + rpi_utils.POWER_FILE,
-                "Disabling brightness buttons"
-            ]
-            event_logger.info("\n".join(msg))
+            event_logger.info("System doesn't appear to be a Raspberry Pi, disabling brightness buttons.")
+
             self.blank_button.setEnabled(False)
             brightness_button.setEnabled(False)
 

--- a/src/rpi_utils.py
+++ b/src/rpi_utils.py
@@ -1,9 +1,7 @@
 # Collectin of Raspberry Pi related helper functions for interacting with screen
 # brightness.
 
-import tempfile
 import logging
-import inspect
 import os
 
 
@@ -14,7 +12,7 @@ HIGH_BRIGHTNESS = 255
 BRIGHTNESS_FILE = "/sys/class/backlight/10-0045/brightness"
 POWER_FILE = "/sys/class/backlight/10-0045/bl_power"
 
-# Older backlight control files for pre Debian Bullseye based Raspberry OS release
+# Older backlight control files for pre-Debian Bullseye based Raspberry OS release
 if not os.path.exists(BRIGHTNESS_FILE):
     BRIGHTNESS_FILE = "/sys/class/backlight/rpi_backlight/brightness"
     POWER_FILE = "/sys/class/backlight/rpi_backlight/bl_power"

--- a/src/rpi_utils.py
+++ b/src/rpi_utils.py
@@ -33,7 +33,7 @@ def require_rpi(func):
     """Wrapper for skipping function calls if not running on a Raspberry Pi."""
     def wrapper(*args, **kwargs):
         if IS_RASPBERRY_PI:
-            func()
+            func(*args, **kwargs)
         else:
             logger.warning(
                 "Not running on a Raspberry Pi, ignoring utility function %s",

--- a/src/rpi_utils.py
+++ b/src/rpi_utils.py
@@ -20,11 +20,34 @@ if not os.path.exists(BRIGHTNESS_FILE):
     POWER_FILE = "/sys/class/backlight/rpi_backlight/bl_power"
 
 
+IS_RASPBERRY_PI = False
+try:
+    with open("/sys/firmware/devicetree/base/model") as f:
+        if "raspberry pi" in f.read().lower():
+            IS_RASPBERRY_PI = True
+except Exception:
+    pass
+
+
+def require_rpi(func):
+    """Wrapper for skipping function calls if not running on a Raspberry Pi."""
+    def wrapper(*args, **kwargs):
+        if IS_RASPBERRY_PI:
+            func()
+        else:
+            logger.warning(
+                "Not running on a Raspberry Pi, ignoring utility function %s",
+                func.__name__
+            )
+    return wrapper
+
+@require_rpi
 def set_display_backlight_brightness(brightness):
     """Write a new brightness value to file."""
-    with _get_config_file_or_tempfile(BRIGHTNESS_FILE, "w") as f:
+    with open(BRIGHTNESS_FILE, "w") as f:
         f.write(str(brightness))
 
+@require_rpi
 def toggle_display_backlight_brightness(low_brightness=12):
     """Reads Raspberry pi touch display's current brightness values from system
     file and toggles it between low and max (255) values depending on the
@@ -40,20 +63,22 @@ def toggle_display_backlight_brightness(low_brightness=12):
 
     set_display_backlight_brightness(new)
 
+@require_rpi
 def toggle_screen_state(state="on"):
     """Toggle screen state between on / off."""
     value = 1
     if state == "on":
         value = 0
 
-    with _get_config_file_or_tempfile(POWER_FILE, "w") as f:
+    with open(POWER_FILE, "w") as f:
         f.write(str(value))
 
+@require_rpi
 def get_and_set_screen_state(new_state):
     """Read the current screen power state and set it to new_state. Returns the
-    previous value ('on'/'off').
+    previous value (on/off).
     """
-    with _get_config_file_or_tempfile(POWER_FILE, "r+") as f:
+    with open(POWER_FILE, "r+") as f:
         previous_value = f.read().strip()
 
         f.seek(0)
@@ -66,35 +91,14 @@ def get_and_set_screen_state(new_state):
         return "on"
     return "off"
 
+@require_rpi
 def _get_current_display_backlight_brightness():
     """Return the current backlight brightness value."""
-    with _get_config_file_or_tempfile(BRIGHTNESS_FILE, "r") as f:
+    with open(BRIGHTNESS_FILE, "r") as f:
         try:
             value = int(f.read().strip())
+        # default to max value if unable to read the file
         except ValueError:
-            value = HIGH_BRIGHTNESS  # default to max value if unable to read the file (ie. is a dummy tempfile)
+            value = HIGH_BRIGHTNESS
 
     return value
-
-def _get_config_file_or_tempfile(file_path, mode="r"):
-    """Return a file object matching a file path. Returns either a
-    file object pointing to an existing file or a TemporaryFile if the file
-    does not exist.
-    """
-    try:
-        return open(file_path, mode=mode)
-    except FileNotFoundError:
-        stack_value = inspect.stack()[1]
-        function = stack_value.function
-        argvalues = inspect.getargvalues(stack_value.frame)
-
-        logger.warning(
-            "Using tempfile instead of non-existing file %s when calling %s with arguments: %s",
-            file_path,
-            function,
-            inspect.formatargvalues(*argvalues)
-        )
-        return tempfile.TemporaryFile(mode=mode)
-    except PermissionError as e:
-        logging.warning("Couldn't open file %s, using tempfile instead. Original error was\n%s", file_path, str(e))
-        return tempfile.TemporaryFile(mode=mode)

--- a/src/rpi_utils.py
+++ b/src/rpi_utils.py
@@ -19,13 +19,12 @@ if not os.path.exists(BRIGHTNESS_FILE):
     POWER_FILE = "/sys/class/backlight/rpi_backlight/bl_power"
 
 
-IS_RASPBERRY_PI = False
 try:
     with open("/sys/firmware/devicetree/base/model") as f:
-        if "raspberry pi" in f.read().lower():
-            IS_RASPBERRY_PI = True
+        IS_RASPBERRY_PI = "raspberry pi" in f.read().lower()
 except Exception:
-    pass
+    IS_RASPBERRY_PI = False
+
 
 
 def require_rpi(func):
@@ -41,17 +40,28 @@ def require_rpi(func):
             )
     return wrapper
 
+
 @require_rpi
+def _get_value(file):
+    with open(file) as f:
+        value = int(f.read().strip())
+    return value
+
+@require_rpi
+def _set_value(file, value):
+    with open(file, "w") as f:
+        f.write(str(value))
+
+
 def set_display_backlight_brightness(brightness):
     """Write a new brightness value to file."""
-    with open(BRIGHTNESS_FILE, "w") as f:
-        f.write(str(brightness))
+    _set_value(BRIGHTNESS_FILE, brightness)
 
 def toggle_display_backlight_brightness(low_brightness=12):
     """Reads current brightness value and toggles it between
     low and max values depending on current value.
     """
-    old = _get_current_display_backlight_brightness()
+    old = _get_value(BRIGHTNESS_FILE)
 
     # set to furthest away from current brightness
     if abs(old-low_brightness) < abs(old-HIGH_BRIGHTNESS):
@@ -61,42 +71,24 @@ def toggle_display_backlight_brightness(low_brightness=12):
 
     set_display_backlight_brightness(new)
 
-@require_rpi
 def toggle_screen_state(state="on"):
     """Toggle screen state between on / off."""
     value = 1
     if state == "on":
         value = 0
 
-    with open(POWER_FILE, "w") as f:
-        f.write(str(value))
+    _set_value(POWER_FILE, value)
 
-@require_rpi
 def get_and_set_screen_state(new_state):
     """Read the current screen power state and set it to new_state. Returns the
     previous value (on/off).
     """
-    with open(POWER_FILE, "r+") as f:
-        previous_value = f.read().strip()
+    previous_value = _get_value(POWER_FILE)
+    value = 1
+    if new_state == "on":
+        value = 0
 
-        f.seek(0)
-        value = 1
-        if new_state == "on":
-            value = 0
-        f.write(str(value))
-
+    _set_value(POWER_FILE, value)
     if previous_value == 0:
         return "on"
     return "off"
-
-@require_rpi
-def _get_current_display_backlight_brightness():
-    """Return the current backlight brightness value."""
-    with open(BRIGHTNESS_FILE, "r") as f:
-        try:
-            value = int(f.read().strip())
-        # default to max value if unable to read the file
-        except ValueError:
-            value = HIGH_BRIGHTNESS
-
-    return value

--- a/src/rpi_utils.py
+++ b/src/rpi_utils.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+from functools import wraps
 
 
 logger = logging.getLogger("eventLogger")
@@ -29,6 +30,7 @@ except Exception:
 
 def require_rpi(func):
     """Wrapper for skipping function calls if not running on a Raspberry Pi."""
+    @wraps(func)
     def wrapper(*args, **kwargs):
         if IS_RASPBERRY_PI:
             func(*args, **kwargs)
@@ -45,11 +47,9 @@ def set_display_backlight_brightness(brightness):
     with open(BRIGHTNESS_FILE, "w") as f:
         f.write(str(brightness))
 
-@require_rpi
 def toggle_display_backlight_brightness(low_brightness=12):
-    """Reads Raspberry pi touch display's current brightness values from system
-    file and toggles it between low and max (255) values depending on the
-    current value.
+    """Reads current brightness value and toggles it between
+    low and max values depending on current value.
     """
     old = _get_current_display_backlight_brightness()
 

--- a/src/rpi_utils.py
+++ b/src/rpi_utils.py
@@ -32,7 +32,7 @@ def require_rpi(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         if IS_RASPBERRY_PI:
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
         else:
             logger.warning(
                 "Not running on a Raspberry Pi, ignoring utility function %s",

--- a/stop.sh
+++ b/stop.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
+
 # Send a debug signal to the main script
 kill -s USR1 $(pgrep -f "python .*(alarmpi/)?main.py")
 
 
-# kill the alarm (if running). Useful for killing radio stream started by cron
+# kill any running alarms
 pkill cvlc
-pkill -f "play_alarm.py"  # only kill the python process running the alarm
+pkill -f "play_alarm.py"
 pkill -f "python .*(alarmpi/)?main.py"
 
 # Ensure backlight is turned on (only on Raspberry Pi)
-FILE=/sys/class/backlight/rpi_backlight/bl_power
-if [[ -f "$FILE" ]]; then
+if [[ -d "/sys/class/backlight/rpi_backlight" ]]; then
+    echo "exists"
     echo 0 > /sys/class/backlight/rpi_backlight/bl_power
     echo 255 > /sys/class/backlight/rpi_backlight/brightness
 fi
 
+if [[ -d "/sys/class/backlight/10-0045" ]]; then
+    echo "exists"
+    echo 0 > /sys/class/backlight/10-0045/bl_power
+    echo 255 > /sys/class/backlight/10-0045/brightness
+fi

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -131,7 +131,7 @@ class TestClockCase():
         # Click again and check value is set back to low
         mock_get_brightness.return_value = 255
         dummy_clock.settings_window.control_buttons["Toggle\nBrightness"].click()
-        mock_set_brightness.assert_called_with(12)  # Default low brightness value is 12
+        mock_set_brightness.assert_called_with(12)
 
     @patch("src.apconfig.AlarmConfig.get_config_file_path")
     def test_brightness_buttons_disabled_on_non_writable_configs(self, mock_get_config_file_path):

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from freezegun import freeze_time
 
-from src import clock
+from src import clock, rpi_utils
 
 
 @patch("src.apconfig.AlarmConfig.get_config_file_path")
@@ -26,6 +26,7 @@ def dummy_clock():
     """
     return create_clock()
 
+rpi_utils.IS_RASPBERRY_PI = True
 
 
 class TestClockCase():
@@ -119,7 +120,7 @@ class TestClockCase():
     @patch("src.rpi_utils.set_display_backlight_brightness")
     @patch("src.rpi_utils._get_current_display_backlight_brightness")
     def test_brightness_toggle(self, mock_get_brightness, mock_set_brightness, dummy_clock):
-        """Does the backlight toggle change brightness change from low to high?"""
+        """Does the backlight toggle change brightness from low to high?"""
         mock_get_brightness.return_value = 12
 
         # Ensure the button is enabled before clicking it

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -26,7 +26,6 @@ def dummy_clock():
     """
     return create_clock()
 
-rpi_utils.IS_RASPBERRY_PI = True
 
 
 class TestClockCase():

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -118,10 +118,10 @@ class TestClockCase():
         assert label_time == "07:16"
 
     @patch("src.rpi_utils.set_display_backlight_brightness")
-    @patch("src.rpi_utils._get_current_display_backlight_brightness")
-    def test_brightness_toggle(self, mock_get_brightness, mock_set_brightness, dummy_clock):
+    @patch("src.rpi_utils._get_value")
+    def test_brightness_toggle(self, mock_get_value, mock_set_brightness, dummy_clock):
         """Does the backlight toggle change brightness from low to high?"""
-        mock_get_brightness.return_value = 12
+        mock_get_value.return_value = 12
 
         # Ensure the button is enabled before clicking it
         dummy_clock.settings_window.control_buttons["Toggle\nBrightness"].setEnabled(True)
@@ -129,7 +129,7 @@ class TestClockCase():
         mock_set_brightness.assert_called_with(255)
 
         # Click again and check value is set back to low
-        mock_get_brightness.return_value = 255
+        mock_get_value.return_value = 255
         dummy_clock.settings_window.control_buttons["Toggle\nBrightness"].click()
         mock_set_brightness.assert_called_with(12)
 

--- a/tests/test_rpi_utils.py
+++ b/tests/test_rpi_utils.py
@@ -1,0 +1,42 @@
+import pytest
+from unittest import mock
+
+from src import rpi_utils
+
+
+@pytest.fixture()
+def enable_pi():
+    rpi_utils.IS_RASPBERRY_PI = True
+
+@pytest.fixture()
+def disable_pi():
+    rpi_utils.IS_RASPBERRY_PI = False
+
+def test_set_value_when_pi(enable_pi):
+    """Is file written to when running on a Raspberry Pi?"""
+    with mock.patch("builtins.open", mock.mock_open()) as mock_file:
+        rpi_utils._set_value("test.txt", 42)
+
+        mock_file.assert_called_once_with("test.txt", "w")
+        mock_file().write.assert_called_once_with("42")
+
+def test_set_value_when_not_pi(disable_pi):
+    """Is file write skipped when not running on a Raspberry Pi?"""
+    with mock.patch("builtins.open", mock.mock_open()) as mock_file:
+        rpi_utils._set_value("test.txt", 42)
+
+        mock_file.assert_not_called()
+
+def test_get_value_when_pi(enable_pi):
+    """Is file read from when running on a Raspberry Pi?"""
+    with mock.patch("builtins.open", mock.mock_open(read_data="1")) as mock_file:
+        rpi_utils._get_value("test.txt")
+
+        mock_file.assert_called_once_with("test.txt")
+
+def test_get_value_when_not_pi(disable_pi):
+    """Is file read skipped when not running on a Raspberry Pi?"""
+    with mock.patch("builtins.open", mock.mock_open(read_data="1")) as mock_file:
+        rpi_utils._get_value("test.txt")
+
+        mock_file.assert_not_called()


### PR DESCRIPTION
Add support for new backlight control files introduced with Debian Bullseye based release.

Better exception handling for control files when not running on Raspberry Pi:
 * refactor to getter/setter model for interacting with control files
 * ignore function calls when not running on Pi
 * add unit tests
 * implement control file permissions as a udev rule as in https://github.com/linusg/rpi-backlight